### PR TITLE
refactor: PlayHistoryで不適切な用途でuseEffectを使っていたため,useMemoに置換

### DIFF
--- a/src/components/PlayHistory/components/ToggleOrder.tsx
+++ b/src/components/PlayHistory/components/ToggleOrder.tsx
@@ -1,27 +1,13 @@
-import { useState } from "react";
-import { ToggleOrderProps } from "../../type";
+import { ToggleOrderProps} from "../../type";
 
-export function ToggleOrder({
-  ascending,
-  setAscending,
-  playHistory,
-  setPlayHistory,
-}: ToggleOrderProps) {
-  const [order, setOrder] = useState<string>("手順:昇順");
-
+export function ToggleOrder({ ascending, changeOrder }: ToggleOrderProps) {
   function handleOrder(): void {
-    const newOrder = !ascending;
-    setAscending(newOrder);
-
-    if (newOrder) {
-      setOrder("手順:昇順");
-    } else {
-      setOrder("手順:降順");
-    }
-
-    const newPlayHistory = playHistory.slice().reverse();
-    setPlayHistory(newPlayHistory);
+    changeOrder((prevAscending) => !prevAscending);
   }
 
-  return <button onClick={() => handleOrder()}>{order}</button>;
+  return (
+    <button onClick={handleOrder}>
+      {ascending ? "手順:昇順" : "手順:降順"}
+    </button>
+  );
 }

--- a/src/components/PlayHistory/index.tsx
+++ b/src/components/PlayHistory/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
 import { PlayHistoryProps } from "../type";
 import { ToggleOrder } from "./components/ToggleOrder";
 
@@ -7,8 +7,6 @@ export function PlayHistory({
   jumpTo,
 }: PlayHistoryProps): JSX.Element {
   const [ascending, setAscending] = useState<boolean>(true);
-
-  const changeOrder = useCallback(setAscending, [setAscending]);
 
   const playHistory = useMemo(() => {
     const newPlayHistory = history.map((_, i) => {
@@ -33,7 +31,7 @@ export function PlayHistory({
 
   return (
     <>
-      <ToggleOrder ascending={ascending} changeOrder={changeOrder} />
+      <ToggleOrder ascending={ascending} changeOrder={setAscending} />
       <ul>{playHistory}</ul>
     </>
   );

--- a/src/components/PlayHistory/index.tsx
+++ b/src/components/PlayHistory/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { PlayHistoryProps } from "../type";
 import { ToggleOrder } from "./components/ToggleOrder";
 
@@ -6,16 +6,17 @@ export function PlayHistory({
   history,
   jumpTo,
 }: PlayHistoryProps): JSX.Element {
-  const [playHistory, setPlayHistory] = useState<JSX.Element[]>([]);
   const [ascending, setAscending] = useState<boolean>(true);
 
-  useEffect(() => {
+  const changeOrder = useCallback(setAscending, [setAscending]);
+
+  const playHistory = useMemo(() => {
     const newPlayHistory = history.map((_, i) => {
       let description;
       if (i === 0) {
         description = "Go to game start";
       } else if (i === history.length - 1) {
-        return <p>▶︎You're at move #{i}</p>;
+        return <p key={i}>▶︎You're at move #{i}</p>;
       } else {
         description = "Go to move #" + i;
       }
@@ -27,21 +28,12 @@ export function PlayHistory({
       );
     });
 
-    if (ascending) {
-      setPlayHistory(newPlayHistory);
-    } else {
-      setPlayHistory(newPlayHistory.reverse());
-    }
-  }, [history, jumpTo]);
+    return ascending ? newPlayHistory : newPlayHistory.reverse();
+  }, [history, jumpTo, ascending]);
 
   return (
     <>
-      <ToggleOrder
-        ascending={ascending}
-        setAscending={setAscending}
-        playHistory={playHistory}
-        setPlayHistory={setPlayHistory}
-      />
+      <ToggleOrder ascending={ascending} changeOrder={changeOrder} />
       <ul>{playHistory}</ul>
     </>
   );

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -1,26 +1,33 @@
 export interface SquareProps {
   value: string;
   onSquareClick: React.MouseEventHandler<HTMLButtonElement>;
-  style: React.CSSProperties;
+  isWinner: boolean | null;
 }
 
 export interface GameStatusProps {
   board: string[][];
   xIsNext: boolean;
+  existWinner: number[][] | null;
+  isNullSquareExist: boolean;
 }
 
-export interface BoardProps extends GameStatusProps {
+export type BoardType = string[][];
+
+export interface BoardProps {
+  board: string[][];
+  xIsNext: boolean;
+  existWinner: number[][] | null;
   onPlay: (board: string[][]) => void;
 }
 
+export type History = string[][][];
+
 export interface PlayHistoryProps {
-  history: string[][][];
+  history: History;
   jumpTo: (move: number) => void;
 }
 
 export interface ToggleOrderProps {
   ascending: boolean;
-  setAscending: React.Dispatch<React.SetStateAction<boolean>>;
-  playHistory: JSX.Element[];
-  setPlayHistory: React.Dispatch<React.SetStateAction<JSX.Element[]>>;
+  changeOrder: React.Dispatch<React.SetStateAction<boolean>>;
 }


### PR DESCRIPTION
お手隙で本PRのレビューをお願いします・・・！

### サマリー
- PlayHistoryでuseEffectを不適切な用途で使用していたためuseMemoに置換しました

### 補足
- https://github.com/RokuMikami/react-typescript-tictactoe/pull/1
  - 上記PRからPlayHistoryの差分のみ抽出したものです

### ローカルでの確認方法
1. ターミナル > ローカルのgithubリポジトリに移動 > 下記コマンドを実行し本ブランチの内容をクローン
  - `git clone -b create_tictactoe https://github.com/RokuMikami/react-typescript-tictactoe.git`
2.  react-typescript-tictactoeにcd
3. `npm run dev` を実行 > LocalのURLをコピー > ブラウザにペーストしアクセスする